### PR TITLE
fix: filter teacher registrations in mentoring teacher popup #249

### DIFF
--- a/frontend/src/pages/courses/view/_components/MentoringTeacherPopup.tsx
+++ b/frontend/src/pages/courses/view/_components/MentoringTeacherPopup.tsx
@@ -68,20 +68,22 @@ const Index = (props: Props) => {
 
   const getDefaultTeacherList = () => {
     return (
-      currentSeason?.registrations.map((reg) => {
-        return {
-          _id: reg.user,
-          userId: reg.userId,
-          userName: reg.userName,
-          tableRowChecked: props.selectedTeachers
-            ? _.find(props.selectedTeachers, {
-                _id: reg.user,
-              })
-              ? true
-              : false
-            : false,
-        };
-      }) ?? []
+      currentSeason?.registrations
+        .filter((reg) => reg.role === "teacher")
+        .map((reg) => {
+          return {
+            _id: reg.user,
+            userId: reg.userId,
+            userName: reg.userName,
+            tableRowChecked: props.selectedTeachers
+              ? _.find(props.selectedTeachers, {
+                  _id: reg.user,
+                })
+                ? true
+                : false
+              : false,
+          };
+        }) ?? []
     );
   };
 


### PR DESCRIPTION
수업 개설 및 수정 시 멘토 선택 팝업에서 학생 리스트가 함께 보이는 버그 수정