### PR TITLE
fix : 문서에서 줄바꿈 이스케이프를 출력 문제

### DIFF
--- a/frontend/src/editor/editor.module.scss
+++ b/frontend/src/editor/editor.module.scss
@@ -399,7 +399,7 @@
                 table {
                     width: 100%;
                     border-color: var(--accent-5);
-                    white-space: pre-wrap;
+                    white-space: pre-line;
 
                     tr {
                         height: 26px;
@@ -553,7 +553,7 @@
     width: 100%;
     table-layout: fixed;
     overflow: hidden;
-    white-space: pre-wrap;
+    white-space: pre-line;
 
     td {
         border: var(--border-default);
@@ -640,7 +640,7 @@ parsed block
     width: 100%;
     table-layout: fixed;
     overflow: hidden;
-    white-space: pre-wrap;
+    white-space: pre-line;
 
     .cell {
         outline: none;

--- a/frontend/src/editor/editor.module.scss
+++ b/frontend/src/editor/editor.module.scss
@@ -399,6 +399,7 @@
                 table {
                     width: 100%;
                     border-color: var(--accent-5);
+                    white-space: pre-wrap;
 
                     tr {
                         height: 26px;
@@ -552,6 +553,7 @@
     width: 100%;
     table-layout: fixed;
     overflow: hidden;
+    white-space: pre-wrap;
 
     td {
         border: var(--border-default);
@@ -638,6 +640,7 @@ parsed block
     width: 100%;
     table-layout: fixed;
     overflow: hidden;
+    white-space: pre-wrap;
 
     .cell {
         outline: none;


### PR DESCRIPTION
문서에서 줄바꿈 이스케이프를 출력 하면서 테이블 내에서 이미지 출력시 줄바꿈 되는 문제를 해결하기 위해서 white-space: pre-line; 으로 수정