### PR TITLE
table textarea width update

### DIFF
--- a/frontend/src/components/popup/popup.module.scss
+++ b/frontend/src/components/popup/popup.module.scss
@@ -46,9 +46,6 @@
     padding-top: 24px;
   }
 }
-::-webkit-scrollbar {
-  display: none;
-}
 
 .popup_background {
   position: fixed;

--- a/frontend/src/components/tableV2/Table.tsx
+++ b/frontend/src/components/tableV2/Table.tsx
@@ -959,12 +959,15 @@ const Table = (props: Props) => {
                               onFocus={(e) => {
                                 e.currentTarget.style.height =
                                   e.currentTarget.scrollHeight + "px";
-                                e.currentTarget.style.width = "300px";
+                                e.currentTarget.style.width = "100%"; // 최소 너비는 100%로 설정
+                                if (e.currentTarget.offsetWidth < 300) {
+                                  e.currentTarget.style.width = "300px"; // 최소 너비가 300px보다 작을 경우 300px로 조정
+                                }
                               }}
-                              onKeyDown={(e) => {
+                              onBlur={(e) => {
                                 e.currentTarget.style.height =
                                   e.currentTarget.scrollHeight + "px";
-                                e.currentTarget.style.width = "300px";
+                                e.currentTarget.style.width = "100%"; // 최소 너비는 100%로 설정
                               }}
                               style={{
                                 whiteSpace: val.whiteSpace,

--- a/frontend/src/components/tableV2/table.module.scss
+++ b/frontend/src/components/tableV2/table.module.scss
@@ -1,18 +1,35 @@
+::-webkit-scrollbar {
+  width: 14px;
+  height: 14px;
+}
+
+::-webkit-scrollbar-thumb {
+  outline: none;
+  border-radius: 10px;
+  border: 4px solid transparent;
+  box-shadow: inset 6px 6px 0 rgba(34, 34, 34, 0.15);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  border: 4px solid transparent;
+  box-shadow: inset 6px 6px 0 rgba(34, 34, 34, 0.3);
+}
+
+::-webkit-scrollbar-track {
+  box-shadow: none;
+  background-color: transparent;
+}
+
 .table_container {
   width: 100%;
-  overflow-x: auto;
+  overflow-x: overlay;
   -ms-overflow-style: none;
-  scrollbar-width: none;
+  scrollbar-width:none;
 }
-
-.table_container::-webkit-scrollbar {
-  display: none;
-}
-
 .table {
   border: var(--border-default);
   width: 100%;
-  position: relative;
+  position: static;
   border-collapse: collapse;
   font-size: 14px;
   text-align: left;

--- a/frontend/src/pages/courses/List.tsx
+++ b/frontend/src/pages/courses/List.tsx
@@ -85,7 +85,6 @@ const Courses = (props: Props) => {
       <Navbar />
       <div className={style.section}>
         <div className={style.title}>수업 목록</div>
-        <div style={{ height: "24px" }}></div>
         {!isLoading ? (
           <CourseTable
             defaultPageBy={50}

--- a/frontend/src/pages/index/Home.tsx
+++ b/frontend/src/pages/index/Home.tsx
@@ -29,7 +29,7 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import style from "../../style/pages/home.module.scss";
-import QuickSearch from "../../components/quickSearch/QuickSearch";
+// import QuickSearch from "../../components/quickSearch/QuickSearch";
 import Navbar from "../../layout/navbar/Navbar";
 import Schedule from "components/schedule/Schedule";
 import { useAuth } from "contexts/authContext";
@@ -115,7 +115,7 @@ const Home = () => {
 
   return (
     <>
-      <QuickSearch />
+      {/* <QuickSearch /> */}
       <Navbar />
       <div className={style.section}>
         <Schedule

--- a/frontend/src/style/pages/enrollment.module.scss
+++ b/frontend/src/style/pages/enrollment.module.scss
@@ -1,5 +1,15 @@
+.section::-webkit-scrollbar {
+  display: none;
+}
+
 .section {
-    margin: 24px;
+  height: calc(100vh - 56px);
+  padding: 24px;
+  overflow-y: auto;
+  color: var(--accent-1);
+
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 
     .title {
         font-size: 18px;
@@ -8,9 +18,8 @@
         color: var(--accent-1);
 
     }
-}
 
-.categories_container {
+  .categories_container {
     overflow: scroll auto;
     -ms-overflow-style: none;
     /* IE and Edge */
@@ -25,18 +34,19 @@
   .categories {
     display: flex;
     gap: 4px;
-
-    .category {
-      cursor: pointer;
-      border: var(--border-default);
-      padding: 10px 14px;
-      font-size: 14px;
-      font-family: Pretendard;
-      font-weight: 500;
-      white-space: nowrap;
-    }
-
-    .category:hover {
-      background-color: #ebebeb;
-    }
   }
+
+  .category {
+    cursor: pointer;
+    border: var(--border-default);
+    padding: 10px 14px;
+    font-size: 14px;
+    font-family: Pretendard;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
+  .category:hover {
+    background-color: #ebebeb;
+  }
+}

--- a/frontend/src/style/pages/home.module.scss
+++ b/frontend/src/style/pages/home.module.scss
@@ -1,8 +1,15 @@
+.section::-webkit-scrollbar {
+    display: none;
+}
+  
 .section {
-    /* margin: 24px; */
-    padding: 24px;
-    height: calc(100% - 56px);
-    overflow: hidden;
+height: calc(100vh - 56px);
+padding: 24px;
+overflow-y: auto;
+color: var(--accent-1);
+
+-ms-overflow-style: none;
+scrollbar-width: none;
     .title {
         font-size: 18px;
         font-weight: 600;


### PR DESCRIPTION
- textarea 입력창의 크기를 onFocus일 때 최대 100%에서 최소 300px로 수정 
- textarea 입력창의 크기를 onFocus일 때 최대 100%로 수정
- 컨텐츠 사이즈가 커져서 container 밖으로 빠져나올때 가로 스크롤 바를 사용 할 수 있도록 하였다.
- 모바일 화면에서 logo 메뉴가 따로 움직이는 오류 수정
- 모바일 화면에서 calendar style로 인해 상단바가 가려지는 문제 수정(추가적인 확인 필요)
- 사용하지 않는 QuickSearch