### PR TITLE
#304 검색 > 시간표에서 수업 클릭시 수업 정보로 이동하지 않는 문제 수정

### DIFF
--- a/frontend/src/editor/parser/blocks/ParsedTableBlock.tsx
+++ b/frontend/src/editor/parser/blocks/ParsedTableBlock.tsx
@@ -400,6 +400,9 @@ const ParsedTableBlock = (props: Props) => {
                 cursor: "pointer",
               }}
               onClick={() => {
+                if (props.onClickCourse && props.idTimetable?.[data?.id]) {
+                  props.onClickCourse(props.idTimetable?.[data?.id]);
+                }
                 if (props.onClickCourse && props.idTimetable?.[data?.name]) {
                   props.onClickCourse(props.idTimetable?.[data?.name]);
                 }

--- a/frontend/src/pages/courses/tab/TimeTableTab.tsx
+++ b/frontend/src/pages/courses/tab/TimeTableTab.tsx
@@ -94,7 +94,7 @@ const Timetable = (props: Props) => {
             defaultTimetable={syllabusLabelByTime(props.courseList)}
             idTimetable={syllabusIdByTime(props.courseList)}
             onClickCourse={(id: string) => {
-              window.open("/courses/enrolled/" + id, "_blank");
+              navigate("/courses/enrolled/" + id);
             }}
             data={currentSeason?.formTimetable}
           />

--- a/frontend/src/pages/userSearchResult/tab/CoursesTab.tsx
+++ b/frontend/src/pages/userSearchResult/tab/CoursesTab.tsx
@@ -6,6 +6,7 @@ import _ from "lodash";
 import { useEffect, useState } from "react";
 import useAPIv2 from "hooks/useAPIv2";
 import CourseTable from "pages/courses/table/CourseTable";
+import {useNavigate} from "react-router-dom";
 
 type Props = {
   user: any;
@@ -104,6 +105,8 @@ const TimeTable = (props: {
 }) => {
   const { currentSeason } = useAuth();
 
+  const navigate = useNavigate();
+
   function syllabusToTime(s: any) {
     let result = {};
     if (s) {
@@ -121,6 +124,22 @@ const TimeTable = (props: {
     return result;
   }
 
+  function syllabusIdByTime(s: any) {
+    let result = {};
+    if (s) {
+      for (let i = 0; i < s.length; i++) {
+        const element = s[i];
+        for (let ii = 0; ii < element.time.length; ii++) {
+          Object.assign(result, {
+            [element.time[ii].label]: element._id,
+          });
+        }
+      }
+    }
+
+    return result;
+  }
+
   if (props.selected !== "timeTable") {
     return null;
   }
@@ -130,6 +149,10 @@ const TimeTable = (props: {
       type="timetable"
       auth="view"
       defaultTimetable={syllabusToTime(props.enrolledCourseList)}
+      idTimetable={syllabusIdByTime(props.enrolledCourseList)}
+      onClickCourse={(id: string) => {
+        navigate(`/courses/enrolled/${id}`);
+      }}
       data={currentSeason?.formTimetable}
     />
   );

--- a/frontend/src/pages/userSearchResult/tab/CoursesTab.tsx
+++ b/frontend/src/pages/userSearchResult/tab/CoursesTab.tsx
@@ -151,7 +151,7 @@ const TimeTable = (props: {
       defaultTimetable={syllabusToTime(props.enrolledCourseList)}
       idTimetable={syllabusIdByTime(props.enrolledCourseList)}
       onClickCourse={(id: string) => {
-        navigate(`/courses/enrolled/${id}`);
+        navigate(`/courses/mentoring/${id}`);
       }}
       data={currentSeason?.formTimetable}
     />


### PR DESCRIPTION
## 이슈 링크
> #304

## 오류 원인
> ParsedTableBlock에서 셀 입력칸에 대한 onClick 이벤트 핸들러가 제대로 실행되지 않음
>  props.idTimetable?.[data?.name] 가 항상 undefined가 됨
>
> https://github.com/bmrdevteam/Altsis/blob/dev/frontend/src/editor/parser/blocks/ParsedTableBlock.tsx#L403-L405

## 해결 방안
> ParsedTableBlock을 수정하여, 셀 클릭 시 props.idTimetable?.[data?.id] 가 true인 경우에도, onClickCourse 클로저를 실행하도록 수정 
> 하위 호환성을 위하여, 기존 조건문은 그대로 유지하였음