### PR TITLE
fix: #302 테이블의 입력 필드의 너비와 높이 조절

### DIFF
--- a/frontend/src/components/tableV2/table.module.scss
+++ b/frontend/src/components/tableV2/table.module.scss
@@ -34,6 +34,7 @@
   font-size: 14px;
   text-align: left;
   color: var(--accent-1);
+  table-layout: fixed;
 
   td,
   th {
@@ -182,8 +183,10 @@
   tbody {
     .item {
       height: 48px;
+      max-height: 300px;
       border-bottom: var(--border-default);
       border-top: var(--border-default);
+      overflow-y: auto;
 
       .icon {
         display: flex;


### PR DESCRIPTION
## 이슈 링크
> #302

## 개선 사항
> - 테이블의 각 셀의 높이는 최대 300px로 제한함
> - 테이블의 각 셀의 너비는 균등분활되도록 수정