### PR TITLE
Update Autofill.tsx

### DIFF
--- a/frontend/src/components/input/Autofill.tsx
+++ b/frontend/src/components/input/Autofill.tsx
@@ -1,23 +1,23 @@
 import React, { useEffect, useRef, useState } from "react";
 import style from "./autoFill.module.scss";
+
 type Props = {
   options: {
     text: string;
     value: string | number;
   }[];
-  style?: any;
-  ref?: any;
+  style?: React.CSSProperties; // style prop 타입을 React.CSSProperties로 변경
+  ref?: React.Ref<HTMLDivElement>; // ref prop 타입을 React.Ref로 변경
   label?: string;
   required?: boolean;
   defaultValue?: any;
   placeholder?: string;
-  setValue?: any;
+  setValue?: (value: string | number) => void; // setValue prop 타입을 명확히
   setState?: React.Dispatch<React.SetStateAction<any>>;
   appearence?: "flat";
   resetOnClick?: boolean;
   onChange?: (value: string | number) => void;
-
-  onEdit?: any;
+  onEdit?: (isEditing: boolean) => void;
 };
 
 const Autofill = (props: Props) => {
@@ -25,38 +25,155 @@ const Autofill = (props: Props) => {
     props.defaultValue || ""
   );
   const [valid, setValid] = useState(true);
-
   const [edit, setEdit] = useState<boolean>(false);
   const selectRef = useRef<HTMLDivElement>(null);
 
-  function handleMousedown(e: MouseEvent) {
-    if (selectRef.current && !selectRef.current.contains(e.target as Node)) {
-      setEdit(false);
-    }
-  }
+  // 컴포넌트 마운트 시 defaultValue 설정 및 외부 클릭 감지
   useEffect(() => {
     document.addEventListener("mousedown", handleMousedown);
-    if (props.options) {
-      props.setValue && props.setValue(props.defaultValue || "");
-      setInputValue(
-        props.options.filter((val) => {
-          return (
-            val.value && val.value.toString() === props.defaultValue?.toString()
-          );
-        })[0]?.text ?? ""
+
+    if (props.options && props.defaultValue !== undefined) {
+      const defaultOption = props.options.find(
+        (val) => val.value?.toString() === props.defaultValue?.toString()
       );
+      if (defaultOption) {
+        setInputValue(defaultOption.text);
+        props.setValue && props.setValue(defaultOption.value);
+      } else {
+        // defaultValue가 options에 없는 경우 입력 필드를 비움
+        setInputValue("");
+        props.setValue && props.setValue("");
+      }
+    } else if (props.defaultValue === undefined) {
+      setInputValue("");
+      props.setValue && props.setValue("");
     }
 
     return () => {
       document.removeEventListener("mousedown", handleMousedown);
     };
-  }, []);
+  }, [props.options, props.defaultValue]); // 의존성 배열에 props.options와 props.defaultValue 추가
 
+  // edit 상태 변경 시 onEdit 콜백 호출
   useEffect(() => {
     if (props.onEdit) {
       props.onEdit(edit);
     }
-  }, [edit]);
+  }, [edit, props.onEdit]); // 의존성 배열에 props.onEdit 추가
+
+  // 외부 클릭 감지 핸들러
+  function handleMousedown(e: MouseEvent) {
+    if (selectRef.current && !selectRef.current.contains(e.target as Node)) {
+      setEdit(false);
+      // 포커스가 사라질 때 현재 입력값의 유효성을 다시 확인하고, 유효하지 않으면 비워줍니다.
+      const matchedOption = props.options.find(
+        (option) => option.text.toLowerCase() === inputValue.toLowerCase()
+      );
+      if (!matchedOption && inputValue !== "") {
+        setInputValue("");
+        props.onChange && props.onChange(""); // 값도 초기화
+        props.setValue && props.setValue("");
+        props.setState && props.setState("");
+      }
+      setValid(true); // 외부 클릭 시 유효성 상태 초기화
+    }
+  }
+
+  // 입력 필드 변경 핸들러
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setInputValue(value);
+
+    // 유효성 검사 및 onChange 호출
+    const matchedOptions = props.options.filter((val) =>
+      val.text.toLowerCase().includes(value.toLowerCase())
+    );
+    const exactMatch = props.options.find(
+      (val) => val.text.toLowerCase() === value.toLowerCase()
+    );
+
+    if (props.required && value === "") {
+      setValid(false);
+      props.onChange && props.onChange("");
+      props.setValue && props.setValue("");
+    } else if (value !== "" && matchedOptions.length === 0) {
+      setValid(false);
+      props.onChange && props.onChange(""); // 유효하지 않은 값일 경우 초기화
+      props.setValue && props.setValue("");
+    } else {
+      setValid(true);
+      if (exactMatch) {
+        props.onChange && props.onChange(exactMatch.value);
+        props.setValue && props.setValue(exactMatch.value);
+      } else if (value === "") {
+        props.onChange && props.onChange("");
+        props.setValue && props.setValue("");
+      }
+    }
+  };
+
+  // 키 다운 핸들러 (Enter, Tab 처리)
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const inputText = e.currentTarget.value;
+    if (e.key === "Enter" || e.key === "Tab") {
+      e.preventDefault();
+      const filteredOptions = props.options.filter((val) =>
+        val.text.toLowerCase().includes(inputText.toLowerCase())
+      );
+
+      if (filteredOptions.length > 0) {
+        // 가장 첫 번째 일치하는 옵션으로 설정
+        const selectedOption = filteredOptions[0];
+        setInputValue(selectedOption.text);
+        props.onChange && props.onChange(selectedOption.value);
+        props.setValue && props.setValue(selectedOption.value);
+        props.setState && props.setState(selectedOption.value);
+        setValid(true);
+      } else if (props.required && inputText === "") {
+        setValid(false);
+      } else {
+        // 일치하는 항목이 없으면 입력 필드를 비움 (선택 사항)
+        setInputValue("");
+        props.onChange && props.onChange("");
+        props.setValue && props.setValue("");
+        props.setState && props.setState("");
+        setValid(false); // 유효하지 않은 상태로 설정
+      }
+      setEdit(false); // Enter 또는 Tab 키 누르면 드롭다운 닫기
+    }
+  };
+
+  // 옵션 클릭 핸들러
+  const handleOptionClick = (value: { text: string; value: string | number }) => {
+    if (props.resetOnClick) {
+      setInputValue(""); // resetOnClick이 true면 입력 필드 비움
+      props.onChange && props.onChange(""); // 값도 초기화
+      props.setValue && props.setValue("");
+      props.setState && props.setState(value.value); // 하지만 setState는 클릭된 값을 전달
+    } else {
+      setInputValue(value.text);
+      props.onChange && props.onChange(value.value);
+      props.setValue && props.setValue(value.value);
+      props.setState && props.setState(value.value);
+    }
+    setEdit(false);
+    setValid(true); // 옵션 선택 시 유효성 상태를 true로 변경
+  };
+
+  // 필터링된 옵션 목록 가져오기
+  const getFilteredOptions = () => {
+    return props.options.filter((val: { text: string; value: string | number }) => {
+      if (inputValue === "") {
+        return true;
+      } else if (
+        val.text &&
+        val.text?.toLowerCase()?.includes(inputValue?.toLowerCase())
+      ) {
+        return true;
+      }
+      return false;
+    });
+  };
 
   return (
     <div
@@ -82,59 +199,16 @@ const Autofill = (props: Props) => {
         placeholder={props.placeholder}
         type="text"
         value={inputValue}
-        onChange={(e) => {
-          setInputValue(e.target.value);
-          if (
-            props.options.filter(
-              (val: { text: string; value: string | number }) => {
-                if (e.target.value === "") {
-                  return val;
-                } else if (
-                  val.text.toLowerCase().includes(e.target.value.toLowerCase())
-                ) {
-                  return val;
-                }
-              }
-            ).length === 0
-          ) {
-            setValid(false);
-          } else {
-            setValid(true);
-          }
-          const o = props.options.filter(
-            (val: { text: string; value: string | number }) =>
-              val.text.toLowerCase() === e.target.value.toLowerCase()
-          );
-          if (props.onChange && e.target.value !== "" && o.length > 0) {
-            props.onChange(o[0].value);
-          }
-
-          if (props.required && e.target.value === "") {
-            setValid(false);
-          }
-        }}
-        onKeyDown={(e) => {
-          // const inputText = e.currentTarget.value;
-          // if (e.key === "Enter" || e.key === "Tab") {
-          //   e.preventDefault();
-          //   const newInput =
-          //     props.options.filter(
-          //       (val: { text: string; value: string | number }) => {
-          //         return val.text
-          //           .toLowerCase()
-          //           ?.includes(inputText.toLowerCase());
-          //       }
-          //     )[0]?.text ?? "";
-          //   setInputValue(newInput);
-          // }
-        }}
+        onChange={handleInputChange}
+        onKeyDown={handleKeyDown} // 활성화된 onKeyDown 핸들러
         className={style.input}
         onFocus={() => {
           setEdit(true);
+          setValid(true); // 포커스 시 유효성 초기화
         }}
       />
 
-      {edit && (valid || inputValue !== "") && (
+      {edit && (valid || inputValue !== "") && getFilteredOptions().length > 0 && (
         <div
           className={style.options}
           style={{
@@ -142,72 +216,15 @@ const Autofill = (props: Props) => {
             borderRadius: props.style?.borderRadius,
           }}
         >
-          {props.options
-            .filter((val: { text: string; value: string | number }) => {
-              if (inputValue === "") {
-                return true;
-              } else if (
-                val.text &&
-                val.text?.toLowerCase()?.includes(inputValue?.toLowerCase())
-              ) {
-                return true;
-              }
-              return false;
-            })
-            .map((value, index) => {
-              return (
-                <div
-                  key={index}
-                  onClick={() => {
-                    setInputValue(value.text);
-                    props.onChange && props.onChange(value.value);
-                    props.setState && props.setState(value.value);
-                    setEdit(false);
-                  }}
-                  className={style.option}
-                >
-                  {value.text}
-                </div>
-              );
-            })}
-        </div>
-      )}
-
-      {edit && (valid || inputValue !== "") && props.resetOnClick && (
-        <div
-          className={style.options}
-          style={{
-            borderTop: "none",
-            borderRadius: props.style?.borderRadius,
-          }}
-        >
-          {props.options
-            .filter((val: { text: string; value: string | number }) => {
-              if (inputValue === "") {
-                return true;
-              } else if (
-                val.text &&
-                val.text?.toLowerCase()?.includes(inputValue?.toLowerCase())
-              ) {
-                return true;
-              }
-              return false;
-            })
-            .map((value, index) => {
-              return (
-                <div
-                  key={index}
-                  onClick={() => {
-                    setInputValue("");
-                    props.setState && props.setState(value.value);
-                    setEdit(false);
-                  }}
-                  className={style.option}
-                >
-                  {value.text}
-                </div>
-              );
-            })}
+          {getFilteredOptions().map((value, index) => (
+            <div
+              key={index}
+              onClick={() => handleOptionClick(value)}
+              className={style.option}
+            >
+              {value.text}
+            </div>
+          ))}
         </div>
       )}
     </div>


### PR DESCRIPTION
솔루션 개요
이 솔루션은 Autofill 컴포넌트의 기능을 개선하고 몇 가지 잠재적인 문제를 해결하는 데 중점을 둡니다.

onKeyDown 핸들러 활성화 및 개선: Enter 또는 Tab 키를 눌렀을 때, 현재 입력된 텍스트와 가장 유사한 자동완성 옵션으로 입력 필드를 채우도록 합니다.
resetOnClick prop 로직 개선: resetOnClick이 true일 때 옵션이 두 번 렌더링되는 문제를 해결하고, 선택 시 입력 필드를 비우는 기능을 올바르게 구현합니다.
코드 가독성 및 유지보수성 향상: 불필요한 중복 코드를 제거하고 로직을 명확하게 합니다.

주요 변경 사항 및 설명
onKeyDown 핸들러 활성화 및 개선:

onKeyDown 이벤트 핸들러(handleKeyDown)가 주석 처리된 것을 해제하고 기능을 추가했습니다. 사용자가 Enter 또는 Tab 키를 누르면 현재 입력된 텍스트와 일치하는 첫 번째 옵션으로 inputValue를 설정하고, 해당 옵션의 value를 onChange, setValue, setState prop을 통해 전달합니다. 일치하는 옵션이 없으면 inputValue를 비우고 setValid(false)로 설정하여 유효하지 않은 상태를 표시합니다. 키 입력 후 드롭다운 목록이 닫히도록 setEdit(false)를 호출합니다.
resetOnClick prop 로직 개선:

기존 코드에서 resetOnClick prop에 따라 옵션 목록이 두 번 렌더링되는 문제를 해결했습니다. 이제 getFilteredOptions() 함수를 통해 한 번만 필터링된 옵션을 가져오고, 이 옵션을 맵핑하여 렌더링합니다. 옵션 클릭 핸들러 (handleOptionClick) 내에서 props.resetOnClick이 true일 경우, inputValue를 빈 문자열로 설정하여 입력 필드를 비우도록 했습니다. 이때 onChange와 setValue도 빈 문자열로 호출하여 상위 컴포넌트에 빈 값을 전달하고, setState는 클릭된 옵션의 value를 그대로 전달합니다. 유효성 검사 로직 개선:

onChange 핸들러에서 입력 값이 변경될 때마다 유효성을 더 정확하게 검사합니다.
required prop이 true이고 입력값이 비어있을 때 valid 상태를 false로 설정합니다. 입력된 텍스트와 일치하는 옵션이 없을 때 valid 상태를 false로 설정합니다.
외부 클릭(handleMousedown)으로 포커스를 잃었을 때, 현재 inputValue가 options에 존재하는 정확한 텍스트와 일치하지 않으면 inputValue를 비우도록 추가했습니다. 이는 사용자가 임의의 텍스트를 입력하고 포커스를 잃었을 때 잘못된 값이 남아있지 않도록 합니다. 옵션 선택 시 setValid(true)를 호출하여 유효성 상태를 리셋합니다.
포커스 시 setValid(true)를 호출하여 유효성 상태를 리셋합니다.
defaultValue 처리 로직 개선:

useEffect에서 props.defaultValue가 설정되어 있을 때, 해당 값과 일치하는 options 내의 text를 inputValue로 설정하도록 로직을 수정했습니다. defaultValue가 options에 없는 경우 inputValue를 비우도록 처리하여 일관성을 높였습니다. 타입 정의 개선:

style prop의 타입을 React.CSSProperties로, ref prop의 타입을 React.Ref<HTMLDivElement>로, setValue prop의 타입을 (value: string | number) => void로 더 구체적으로 명시하여 타입 안정성을 높였습니다.