### PR TITLE
Fix dataRepeat index handling in table blocks

### DIFF
--- a/frontend/src/editor/layout/sidebar/DataConnPopup.tsx
+++ b/frontend/src/editor/layout/sidebar/DataConnPopup.tsx
@@ -32,9 +32,21 @@ const DataConnPopup = (props: Props) => {
 
   const textareaRef = useRef<HTMLDivElement>(null);
 
+  const existingIndex = getCurrentBlock()?.data?.dataRepeat?.index;
+  const currentRow = getCurrentCellIndex()?.row;
+  const tableRowCount = getCurrentBlock()?.data?.table?.length ?? 1;
+  const getValidIndex = () => {
+    if (typeof existingIndex === "number" && existingIndex < tableRowCount) {
+      return existingIndex;
+    }
+    if (typeof currentRow === "number" && currentRow < tableRowCount) {
+      return currentRow;
+    }
+    return 0;
+  };
   const repeat = useRef<any>({
     by: getCurrentBlock()?.data?.dataRepeat?.by ?? "",
-    index: getCurrentBlock()?.data?.dataRepeat?.index ?? "",
+    index: getValidIndex(),
     max: getCurrentBlock()?.data?.dataRepeat?.max ?? "",
   });
   const [filters, setFilters] = useState<any[]>(

--- a/frontend/src/editor/parser/blocks/ParsedTableBlock.tsx
+++ b/frontend/src/editor/parser/blocks/ParsedTableBlock.tsx
@@ -544,7 +544,8 @@ const ParsedTableBlock = (props: Props) => {
       <SetColumn />
       <tbody>
       {props.blockData.data.table.map((value: any[], index: number) => {
-      if (props.blockData.data.dataRepeat?.index === index) {
+      const repeatIndex = props.blockData.data.dataRepeat?.index;
+      if (typeof repeatIndex === "number" && repeatIndex === index) {
       return (
       filteredRepeat &&
       filteredRepeat.map((v: any, i: number) => {


### PR DESCRIPTION
Improves the logic for determining the dataRepeat index in DataConnPopup to ensure a valid index is used. Also updates ParsedTableBlock to check that dataRepeat.index is a number before comparing, preventing potential rendering issues.